### PR TITLE
Absolute/relative filters, custom delimiter for CLI output

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ var srcs = oust(htmlString, 'links');
 var srcs = oust(htmlString, 'images');
 ```
 
+#### Extract only relative or absolute references
+
+```js
+var hrefs = oust(htmlString, 'stylesheets', 'relative');
+var hrefs = oust(htmlString, 'stylesheets', 'absolute');
+```
+
+
 ## API
 
 #### Options
@@ -58,6 +66,7 @@ Attribute       | Default   | Description
 ---             | ---       | ---
 `src`           | ``        | a valid HTML string to parse for references
 `type`          | ``        | one of `stylesheets`, `scripts`, `imports`, `links`, `images`
+`filter`        | ``        | optional, one of `absolute`, `relative`
 
 
 ## CLI
@@ -70,7 +79,7 @@ $ npm install --global oust
 Extract URLs to stylesheets, scripts, links, images or HTML imports from HTML
 
 Usage:
-    $ oust <filename> <type>
+    $ oust <filename> <type> <filter>
 ```
 
 #### Extract stylesheets references `<link rel="stylesheet">`
@@ -103,6 +112,18 @@ $ oust myFile.html links
 $ oust myFile.html images
 ```
 
+#### Extract only relative or absolute references
+
+```sh
+$ oust myFile.html stylesheets relative
+$ oust myFile.html stylesheets absolute
+```
+
+#### Override newline delimiter with a custom string
+
+```sh
+$ oust -d " " myFile.html stylesheets
+```
 
 ## License
 

--- a/cli.js
+++ b/cli.js
@@ -10,10 +10,10 @@ function printHelp() {
         pkg.description,
         '',
         'Usage',
-        '  $ oust <filename> <type>',
+        '  $ oust <filename> <type> <filter>',
         '',
         'Example',
-        '  $ oust index.html scripts'
+        '  $ oust index.html scripts relative'
     ].join('\n'));
 }
 
@@ -29,6 +29,12 @@ if (argv.h || argv.help || argv._.length === 0) {
 
 var file = argv._[0];
 var type = argv._[1];
+var filter = argv._[2];
+var delimiter = '\n';
+
+if (argv.d) {
+    delimiter = argv.d;
+}
 
 fs.readFile(file, function (err, data) {
     if (err) {
@@ -36,5 +42,5 @@ fs.readFile(file, function (err, data) {
         process.exit(1);
     }
 
-    console.log(oust(data, type).join('\n'));
+    console.log(oust(data, type, filter).join(delimiter));
 });

--- a/index.js
+++ b/index.js
@@ -41,15 +41,26 @@ var types = {
     }
 };
 
-module.exports = function (src, type) {
+var absolute_filter = '[__attribute__^="http:"],[__attribute__^="https:"],[__attribute__^="//"]';
+
+module.exports = function (src, type, filter) {
     if (!src || !type) {
         throw new Error('`src` and `type` required');
     }
 
     var chosenType = types[type];
     var $ = cheerio.load(src);
+    var $selected = $(chosenType.selector);
 
-    return $(chosenType.selector).map(function (i, el) {
+    if (filter) {
+        var f = absolute_filter.replace(/__attribute__/g, chosenType.attribute);
+        if (filter == "relative") {
+            f = ":not(" + f + ")";
+        }
+        $selected = $selected.filter(f);
+    }
+
+    return $selected.map(function (i, el) {
         return $(el).attr(chosenType.attribute);
     }).toArray();
 };

--- a/test/index.js
+++ b/test/index.js
@@ -5,9 +5,12 @@ var oust = require('../');
 
 it('should return an array of stylesheet link hrefs', function () {
     var links = oust(fs.readFileSync('test/sample/index.html', 'utf8'), 'stylesheets');
-    assert(links.length === 2);
-    assert(links[0] === 'bower_components/bootstrap/dist/css/bootstrap.css');
-    assert(links[1] === 'styles/main.css');
+    assert(links.length === 5);
+    assert(links[0] === 'http://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css');
+    assert(links[1] === 'https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css');
+    assert(links[2] === '//maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css');
+    assert(links[3] === 'bower_components/bootstrap/dist/css/bootstrap.css');
+    assert(links[4] === 'styles/main.css');
 });
 
 it('should return an array of refs when passed a HTML string', function () {
@@ -56,3 +59,19 @@ it('should fail if no valid type is specified', function () {
         oust(fs.readFileSync('test/imports.html', 'utf8'));
     });
 });
+
+it('should return an array of relative URLs', function () {
+    var links = oust(fs.readFileSync('test/sample/index.html', 'utf8'), 'stylesheets', 'relative');
+    assert(links.length === 2);
+    assert(links[0] === 'bower_components/bootstrap/dist/css/bootstrap.css');
+    assert(links[1] === 'styles/main.css');
+});
+
+it('should return an array of absolute URLs', function () {
+    var links = oust(fs.readFileSync('test/sample/index.html', 'utf8'), 'stylesheets', 'absolute');
+    assert(links.length === 3);
+    assert(links[0] === 'http://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css');
+    assert(links[1] === 'https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css');
+    assert(links[2] === '//maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css');
+});
+

--- a/test/sample/index.html
+++ b/test/sample/index.html
@@ -6,6 +6,9 @@
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
+        <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
+        <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
         <link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.css" />
         <link rel="stylesheet" href="styles/main.css">
     </head>
@@ -44,7 +47,7 @@
                 <img src="http://placekitten.com/300/400">
                 <img src="http://placekitten.com/500/600">
             </div>
-            
+
             <script src="scripts/main.js"></script>
 
             <div class="footer">


### PR DESCRIPTION
In order to use oust to extract URLs for concatenation/minification, I need only relative URLs (i.e. only stylesheets/scripts that come from my project).

``` js
var hrefs = oust(htmlString, 'stylesheets');
var hrefs = oust(htmlString, 'stylesheets', 'relative');
var hrefs = oust(htmlString, 'stylesheets', 'absolute');
```

``` sh
$ oust index.html stylesheets
$ oust index.html stylesheets relative
$ oust index.html stylesheets absolute
```

Because I'd like to pipe these URLs into another command (e.g. uglifyjs), I need the URLs to be space-delimited, rather than newline-delimited per the oust CLI hard-coded default.

``` sh
$ oust -d " " index.html
```
