### PR TITLE
fix: add noscript option to prevent duplicates

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -38,6 +38,36 @@ it('should return an array of stylesheet link cheerio elements', () => {
     assert(links[1].value === 'styles/print.css');
 });
 
+it('should return an array of stylesheet hrefs excluding noscript', () => {
+    const links = oust(fs.readFileSync('test/noscript.html', 'utf8'), 'stylesheets', false);
+    assert(Array.isArray(links));
+    assert(links.length === 1);
+    assert(links[0] === 'styles/main.css');
+});
+
+it('should return an array of stylesheet hrefs including noscript', () => {
+    const links = oust(fs.readFileSync('test/noscript.html', 'utf8'), 'stylesheets', true);
+    assert(Array.isArray(links));
+    assert(links.length === 2);
+    assert(links[0] === 'styles/main.css');
+    assert(links[1] === 'styles/main.css');
+});
+
+it('should return an array of stylesheet link excluding noscript', () => {
+    const links = oust.raw(fs.readFileSync('test/noscript.html', 'utf8'), 'stylesheets', false);
+    assert(Array.isArray(links));
+    assert(links.length === 1);
+    assert(links[0].value === 'styles/main.css');
+});
+
+it('should return an array of stylesheet link including noscript', () => {
+    const links = oust.raw(fs.readFileSync('test/noscript.html', 'utf8'), 'stylesheets', true);
+    assert(Array.isArray(links));
+    assert(links.length === 2);
+    assert(links[0].value === 'styles/main.css');
+    assert(links[1].value === 'styles/main.css');
+});
+
 it('should return an array of script srcs', () => {
     const links = oust(fs.readFileSync('test/sample/index.html', 'utf8'), 'scripts');
     assert(Array.isArray(links));

--- a/test/noscript.html
+++ b/test/noscript.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+    <link rel="stylesheet" href="styles/main.css">
+    <noscript><link rel="stylesheet" href="styles/main.css"></noscript>
+
+</head>
+<body>
+
+</body>
+</html>


### PR DESCRIPTION
When using preload for stylesheets, it's a common practice to include the stylesheet without a preload wrapped with `noscript`. 

Currently `oust` finds all stylesheets even when they are wrapped with `noscript`, which causes duplicate stylesheets to be returned.

This causes a bug in https://github.com/addyosmani/critical/pull/379 where you'll have duplicate CCSS.

For backward compatibility and without causing a breaking change, `noscript` variable has been set to `true` by default, even though `false` would probably be the required functionality by most users.