### PR TITLE
Don’t throw when an empty source is passed

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ const types = {
 };
 
 function oust(src, type, raw) {
-    if (!src || !type) {
+    if (typeof src !== 'string' || !type) {
         throw new Error('`src` and `type` required');
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -113,6 +113,12 @@ it('should return an array of image sources', () => {
     assert.deepStrictEqual(links, expected);
 });
 
+it('should not fail if an empty source is passed', () => {
+    assert.doesNotThrow(() => {
+        oust(read('test/empty.html'), 'stylesheets');
+    });
+});
+
 it('should fail if no source is specified', () => {
     assert.throws(() => {
         oust();


### PR DESCRIPTION
I think the diff says it all:
<img width="1352" alt="Screenshot 2020-06-02 at 11 04 31" src="https://user-images.githubusercontent.com/9154236/83501745-dad09400-a4c0-11ea-94d1-c89541acb81b.png">

The current condition is a little too “simple” and throws on empty sources (`''`) when it could just ignore them.

Initially motivated by this issue. https://github.com/Tom-Bonnike/netlify-plugin-inline-critical-css/issues/8